### PR TITLE
feat: add gateway address binding support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,3 @@ node_modules
 yarn.lock
 generate
 openapitools.json
-casaos-gateway

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ node_modules
 yarn.lock
 generate
 openapitools.json
+casaos-gateway

--- a/README.md
+++ b/README.md
@@ -19,7 +19,17 @@ $HOME/.casaos/gateway.ini
 /etc/casaos/gateway.ini
 ```
 
-See [gateway.ini.sample](./build/etc/casaos/gateway.ini.sample) for default configuration.
+See [gateway.ini.sample](./build/sysroot/etc/casaos/gateway.ini.sample) for default configuration.
+
+To bind the gateway to a specific interface/IP, set `address` under the `[gateway]` section. Leaving `address` empty keeps the existing behavior (bind to all interfaces).
+
+Example:
+
+```ini
+[gateway]
+port=8080
+address=10.1.1.5
+```
 
 ## Running
 
@@ -27,7 +37,7 @@ Once running, gateway address and management address will be available in the fi
 
 ```bash
 $ cat /var/run/casaos/gateway.url 
-[::]:8080 # port is specified in configuration
+10.1.1.5:8080 # address/port are specified in configuration
 
 $ cat /var/run/casaos/management.url 
 [::]:34703 # port is randomly assigned

--- a/build/sysroot/etc/casaos/gateway.ini.sample
+++ b/build/sysroot/etc/casaos/gateway.ini.sample
@@ -3,3 +3,4 @@ runtimepath=/var/run/casaos
 
 [gateway]
 port=
+address=

--- a/common/config.go
+++ b/common/config.go
@@ -15,6 +15,7 @@ const (
 	ConfigKeyLogSaveName = "gateway.LogSaveName"
 	ConfigKeyLogFileExt  = "gateway.LogFileExt"
 	ConfigKeyGatewayPort = "gateway.Port"
+	ConfigKeyGatewayAddr = "gateway.Address"
 	ConfigKeyRuntimePath = "common.RuntimePath"
 
 	GatewayName       = "gateway"
@@ -27,6 +28,7 @@ func LoadConfig() (*viper.Viper, error) {
 	config.SetDefault(ConfigKeyLogPath, constants.DefaultLogPath)
 	config.SetDefault(ConfigKeyLogSaveName, GatewayName)
 	config.SetDefault(ConfigKeyLogFileExt, "log")
+	config.SetDefault(ConfigKeyGatewayAddr, "")
 
 	config.SetDefault(ConfigKeyRuntimePath, constants.DefaultRuntimePath) // See https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s13.html
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	// Required for `//go:embed` of `gateway.ini.sample`.
 	_ "embed"
 	"errors"
 	"flag"
@@ -65,20 +66,18 @@ func init() {
 
 	// create default config file if not exist
 	ConfigFilePath := filepath.Join(constants.DefaultConfigPath, common.GatewayName+"."+common.GatewayConfigType)
-	if _, err := os.Stat(ConfigFilePath); os.IsNotExist(err) {
-		fmt.Println("config file not exist, create it")
-		// create config file
-		file, err := os.Create(ConfigFilePath)
-		if err != nil {
-			panic(err)
-		}
-		defer file.Close()
+	if err := os.MkdirAll(filepath.Dir(ConfigFilePath), 0o755); err != nil {
+		panic(err)
+	}
 
-		// write default config
-		_, err = file.WriteString(_confSample)
-		if err != nil {
+	file, err := os.OpenFile(ConfigFilePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err == nil {
+		defer file.Close()
+		if _, err := file.WriteString(_confSample); err != nil {
 			panic(err)
 		}
+	} else if !errors.Is(err, os.ErrExist) {
+		panic(err)
 	}
 
 	config, err := common.LoadConfig()
@@ -147,6 +146,7 @@ func main() {
 	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	kill := make(chan os.Signal, 1)
 	signal.Notify(kill, syscall.SIGTERM, syscall.SIGINT)
 
@@ -326,7 +326,7 @@ func run(
 	})
 }
 
-func reloadGateway(address string, port string, route *http.ServeMux) error {
+func reloadGateway(address, port string, route *http.ServeMux) error {
 	listener, err := net.Listen("tcp", net.JoinHostPort(address, port))
 	if err != nil {
 		return err
@@ -423,7 +423,7 @@ func writePidFile(runtimePath string) (string, error) {
 	return filename, os.WriteFile(filepath, []byte(fmt.Sprintf("%d", os.Getpid())), 0o600)
 }
 
-func writeAddressFile(runtimePath string, filename string, address string) (string, error) {
+func writeAddressFile(runtimePath, filename, address string) (string, error) {
 	err := os.MkdirAll(runtimePath, 0o755)
 	if err != nil {
 		return "", err

--- a/main.go
+++ b/main.go
@@ -46,6 +46,8 @@ var (
 	_confSample string
 )
 
+const gatewayURLFilename = "gateway.url"
+
 func init() {
 	versionFlag := flag.Bool("v", false, "version")
 	wwwPathFlag := flag.String("w", filepath.Join(constants.DefaultDataPath, "www"), "www path")
@@ -102,6 +104,12 @@ func init() {
 		panic(err)
 	}
 
+	gatewayAddress := config.GetString(common.ConfigKeyGatewayAddr)
+	if err := _state.SetGatewayAddress(gatewayAddress); err != nil {
+		logger.Error("Failed to set gateway address", zap.Any("error", err), zap.Any(common.ConfigKeyGatewayAddr, gatewayAddress))
+		panic(err)
+	}
+
 	if err := _state.SetWWWPath(*wwwPathFlag); err != nil {
 		logger.Error("Failed to set www path", zap.Any("error", err), zap.String("wwwpath", *wwwPathFlag))
 		panic(err)
@@ -127,7 +135,7 @@ func main() {
 
 	defer cleanupFiles(
 		_state.GetRuntimePath(),
-		pidFilename, external.ManagementURLFilename, external.StaticURLFilename,
+		pidFilename, external.ManagementURLFilename, external.StaticURLFilename, gatewayURLFilename,
 	)
 
 	defer func() {
@@ -268,10 +276,10 @@ func run(
 				}
 
 				_state.OnGatewayPortChange(func(port string) error {
-					return reloadGateway(port, route)
+					return reloadGateway(_state.GetGatewayAddress(), port, route)
 				})
 
-				if err := reloadGateway(_state.GetGatewayPort(), route); err != nil {
+				if err := reloadGateway(_state.GetGatewayAddress(), _state.GetGatewayPort(), route); err != nil {
 					return err
 				}
 
@@ -318,8 +326,8 @@ func run(
 	})
 }
 
-func reloadGateway(port string, route *http.ServeMux) error {
-	listener, err := net.Listen("tcp", net.JoinHostPort("", port))
+func reloadGateway(address string, port string, route *http.ServeMux) error {
+	listener, err := net.Listen("tcp", net.JoinHostPort(address, port))
 	if err != nil {
 		return err
 	}
@@ -352,6 +360,10 @@ func reloadGateway(port string, route *http.ServeMux) error {
 	// test if gateway is running
 	url := "http://" + addr + "/ping"
 	if err := checkURLWithRetry(url, 10); err != nil {
+		return err
+	}
+
+	if _, err := writeAddressFile(_state.GetRuntimePath(), gatewayURLFilename, net.JoinHostPort(address, port)); err != nil {
 		return err
 	}
 

--- a/service/state.go
+++ b/service/state.go
@@ -4,6 +4,8 @@ type State struct {
 	gatewayPort         string
 	onGatewayPortChange []func(string) error
 
+	gatewayAddress string
+
 	runtimePath string
 	wwwPath     string
 }
@@ -12,6 +14,8 @@ func NewState() *State {
 	return &State{
 		gatewayPort:         "",
 		onGatewayPortChange: make([]func(string) error, 0),
+
+		gatewayAddress: "",
 
 		runtimePath: "",
 		wwwPath:     "",
@@ -29,6 +33,15 @@ func (c *State) SetGatewayPort(port string) (err error) {
 
 func (c *State) GetGatewayPort() string {
 	return c.gatewayPort
+}
+
+func (c *State) SetGatewayAddress(address string) error {
+	c.gatewayAddress = address
+	return nil
+}
+
+func (c *State) GetGatewayAddress() string {
+	return c.gatewayAddress
 }
 
 // Add func `f` to the stack. The stack of funcs will be called, in reverse order, when there is request to change the port.


### PR DESCRIPTION
## Summary

Currently, CasaOS Gateway always binds to all interfaces (`[::]`), with no way to restrict it to a specific IP address. This PR adds an `address` configuration option to allow operators to bind the gateway to a specific network interface.

## Changes

**`common/config.go`**
- Added `ConfigKeyGatewayAddr = "gateway.Address"` constant
- Added default value of `""` (empty = bind all interfaces, fully backwards compatible)

**`service/state.go`**
- Added `gatewayAddress` field to the `State` struct
- Added `SetGatewayAddress()` and `GetGatewayAddress()` methods

**`main.go`**
- Reads `gateway.Address` from config on startup and stores it in state
- Passes address through to `reloadGateway()` alongside the existing port
- `reloadGateway(port, route)` → `reloadGateway(address, port, route)` — uses `net.JoinHostPort(address, port)` for the listener
- Writes the bound address+port to `gateway.url` in the runtime path
- Added `gateway.url` to the cleanup list on shutdown

**`build/sysroot/etc/casaos/gateway.ini.sample`**
- Added `address=` field under `[gateway]` section

**`.gitignore`**
- Added `casaos-gateway` binary to ignore list

## Behaviour

- **Default (empty address):** binds to `[::]` — identical to previous behaviour, no breaking change
- **With address set:** binds only to the specified IP, e.g.:

```ini
[gateway]
port=80
address=10.1.1.5
```

This allows running CasaOS on a multi-homed server and restricting the gateway to a specific interface, without needing external firewall rules.

## Testing

Tested on a Dell Wyse thin client running Ubuntu with multiple network interfaces. Gateway correctly binds only to the configured IP and is unreachable on other interfaces.